### PR TITLE
Fix broken personal API key authentication

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -176,7 +176,7 @@ export class LinearAuth {
         expiresAt: Number.MAX_SAFE_INTEGER, // PATs don't expire
       };
       this.linearClient = new LinearClient({
-        accessToken: config.accessToken,
+        apiKey: config.accessToken,
       });
     } else {
       // OAuth flow


### PR DESCRIPTION
LinearClient was being initialized incorrectly for this mode.